### PR TITLE
updated save project functionality

### DIFF
--- a/MSSPM_GuiEstimation/nmfEstimationTab01.cpp
+++ b/MSSPM_GuiEstimation/nmfEstimationTab01.cpp
@@ -207,9 +207,10 @@ nmfEstimation_Tab1::callback_ModifyReleasedSL()
         } else {
             emit CheckAllEstimationTablesAndRun();
         }
-    } else {
-        QApplication::restoreOverrideCursor();
     }
+
+    QApplication::restoreOverrideCursor();
+
 }
 
 void

--- a/MSSPM_GuiSetup/nmfSetupTab02.cpp
+++ b/MSSPM_GuiSetup/nmfSetupTab02.cpp
@@ -125,9 +125,8 @@ nmfSetup_Tab2::callback_Setup_Tab2_SaveProject()
         return;
     }
 
-    m_ProjectName = getProjectName();
+    m_ProjectName     = getProjectName();
     m_ProjectDatabase = getProjectDatabase();
-
     if (! isProjectNameValid(m_ProjectName)) {
         return;
     }
@@ -1150,6 +1149,9 @@ nmfSetup_Tab2::callback_Setup_Tab2_AddDatabase()
     // Auto save project
     callback_Setup_Tab2_SaveProject();
 
+    // Set Navigator to Setup enabled only mode
+    emit AddedNewDatabase();
+
 } // end callback_Setup_Tab2_AddDatabase
 
 
@@ -1322,11 +1324,13 @@ nmfSetup_Tab2::loadProject(nmfLogger *logger, QString fileName)
 
     file.close();
 
+    initDatabase(m_ProjectDatabase);
+
     saveSettings();
     emit LoadProject();
     readSettings();
 
-    initDatabase(m_ProjectDatabase);
+//    initDatabase(m_ProjectDatabase);
 
     logger->logMsg(nmfConstants::Normal,"loadProject end");
 

--- a/MSSPM_GuiSetup/nmfSetupTab02.h
+++ b/MSSPM_GuiSetup/nmfSetupTab02.h
@@ -80,6 +80,7 @@ class nmfSetup_Tab2: public QObject
 
 
 signals:
+    void AddedNewDatabase();
     /**
      * @brief Signal emitted to clear the Estimation data tables
      * after user has deleted the current database

--- a/MSSPM_Main/forms/Main/TableNamesDlg.ui
+++ b/MSSPM_Main/forms/Main/TableNamesDlg.ui
@@ -32,6 +32,12 @@
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
         <widget class="QLabel" name="tableNamesLB">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
          <property name="text">
           <string>Tables in database:</string>
          </property>

--- a/MSSPM_Main/nmfMainWindow.cpp
+++ b/MSSPM_Main/nmfMainWindow.cpp
@@ -2476,6 +2476,8 @@ nmfMainWindow::initConnections()
             this,            SLOT(callback_ClearEstimationTables()));
     connect(Setup_Tab2_ptr,  SIGNAL(ProjectSaved()),
             this,            SLOT(callback_ProjectSaved()));
+    connect(Setup_Tab2_ptr,  SIGNAL(AddedNewDatabase()),
+            this,            SLOT(callback_AddedNewDatabase()));
     connect(Setup_Tab3_ptr,  SIGNAL(ReloadWidgets()),
             this,            SLOT(callback_ReloadWidgets()));
     connect(Setup_Tab4_ptr,  SIGNAL(SaveMainSettings()),
@@ -7067,8 +7069,29 @@ nmfMainWindow::callback_LoadProject()
 
   connect(Setup_Tab2_ptr, SIGNAL(LoadProject()),
           this,           SLOT(callback_LoadProject()));
+
+  enableApplicationFeatures("AllOtherGroups",setupIsComplete());
 }
 
+bool
+nmfMainWindow::setupIsComplete()
+{
+    // Setup is complete iff at least one guild, one species,
+    // and one system have been created.
+    int NumSpecies;
+    int NumGuilds;
+    QString LoadedSystem;
+    QStringList SpeciesList;
+    QStringList GuildList;
+
+    getSpecies(NumSpecies,SpeciesList);
+    getGuilds( NumGuilds, GuildList);
+    LoadedSystem = Setup_Tab4_ptr->getSystemFile();
+
+    return ((NumSpecies > 1) &&
+            (NumGuilds  > 1) &&
+            (! LoadedSystem.isEmpty()));
+}
 
 void
 nmfMainWindow::callback_SaveMainSettings()
@@ -9675,10 +9698,19 @@ nmfMainWindow::loadModelParamObj(ModelFormParameters* ptr)
 */
 
 void
+nmfMainWindow::callback_AddedNewDatabase()
+{
+    updateWindowTitle();
+    enableApplicationFeatures("SetupGroup",true);
+    enableApplicationFeatures("AllOtherGroups",false);
+}
+
+void
 nmfMainWindow::callback_ProjectSaved()
 {
     updateWindowTitle();
     enableApplicationFeatures("SetupGroup",true);
+    enableApplicationFeatures("AllOtherGroups",setupIsComplete());
 }
 
 void
@@ -10379,10 +10411,12 @@ nmfMainWindow::callback_CheckEstimationTablesAndRun()
     if (dataCheck.first) {
         callback_RunEstimation(nmfConstantsMSSPM::DontShowDiagnosticsChart);
     } else {
-        msg  = "Invalid or missing data found in input Estimation table: " + dataCheck.second;
+//      msg  = "Invalid or missing data found in input Estimation table: " + dataCheck.second;
+        msg  = "Invalid or missing data found in one or more input Estimation tables.";
         m_Logger->logMsg(nmfConstants::Error,msg.toStdString());
-        msg  = "Invalid or missing data found in input Estimation table:\n\n" + dataCheck.second;
-        msg += "\n\nPlease check this and all input tables for complete data.";
+//      msg  = "Invalid or missing data found in input Estimation table:\n\n" + dataCheck.second;
+//      msg += "\n\nPlease check this and all input tables for complete data.";
+        msg += "\n\nPlease check all input tables for complete data.";
         QMessageBox::critical(this, "Error",
                               "\n"+msg+"\n", QMessageBox::Ok);
         QApplication::restoreOverrideCursor();

--- a/MSSPM_Main/nmfMainWindow.h
+++ b/MSSPM_Main/nmfMainWindow.h
@@ -565,6 +565,7 @@ private:
     void setNumLines(int numLines);
     void setup2dChart();
     void setup3dChart();
+    bool setupIsComplete();
     void setupOutputChartWidgets();
     void setupOutputEstimateParametersWidgets();
     void setupOutputModelFitSummaryWidgets();
@@ -865,6 +866,7 @@ public slots:
      * @brief Callback invoked when a user has saved new project settings
      */
     void callback_ProjectSaved();
+    void callback_AddedNewDatabase();
     /**
      * @brief Callback invoked when the progress chart timer times out. In this fashion,
      * the progress chart is updated while another process is running.


### PR DESCRIPTION
Hi Elliot,

I made some updates to MSSPM.  If you would compile my latest changes and test them, I'd appreciate it.

The changes were:

1. Crashing on moving the vertical slider in Population Parameters
2. When user creates a new database, the non-Setup groups in the Navigator should become disabled until the user creates at least one Species, one Guild, and one System.  This fixes the crash that you found...which still existed as I was able to get it to crash after some effort.
3. Now when you Save a Project, the database will actually load the appropriate Species, Guilds, and other input tables.  

Thanks.

-Ron
